### PR TITLE
Remove parsing loop

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -77,9 +77,7 @@ let _ =
   let dia_file = In_channel.input_all ch in
   let _ = In_channel.close ch in
   let lexbuf = Lexing.from_string dia_file in
-  while true do 
-    let result = Parser.dia Lexer.parse_code lexbuf in
-      print_endline generate_header;
-      List.iter (fun f -> dia_custom_function f result.custom_functions) result.custom_functions;
-      dia_main result dia_file
-  done
+  let result = Parser.dia Lexer.parse_code lexbuf in
+  print_endline generate_header;
+  List.iter (fun f -> dia_custom_function f result.custom_functions) result.custom_functions;
+  dia_main result dia_file


### PR DESCRIPTION
## Summary
- parse input file only once instead of looping forever

## Testing
- `make ocamlopt`

------
https://chatgpt.com/codex/tasks/task_e_6849262e1cb4832f8cf03fd93d4c610b