### PR TITLE
Add Alcotest-based test

### DIFF
--- a/dia.mli
+++ b/dia.mli
@@ -1,5 +1,7 @@
 val dia_dbgprint : string -> unit
 
+val dia_create_cpp_variable : int -> string
+
 val dia_debug_function_descriptor : DiaNode.dia_node -> int -> unit
 
 val dia_generate_code : DiaNode.dia_node -> DiaNode.dia_node list -> int -> DiaNode.dia_node * int

--- a/dune
+++ b/dune
@@ -1,5 +1,11 @@
 (ocamllex lexer)
 (ocamlyacc parser)
 
+(library
+ (name dia)
+ (modules dia diaNode predefined))
+
 (executable
-  (name main))
+ (name main)
+ (modules main lexer parser)
+ (libraries dia))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_dia)
+ (libraries dia alcotest))

--- a/test/test_dia.ml
+++ b/test/test_dia.ml
@@ -10,3 +10,4 @@ let () =
     ("dia_create_cpp_variable",
      [test_case "creates variables" `Quick test_create_cpp_variable]);
   ]
+

--- a/test/test_dia.ml
+++ b/test/test_dia.ml
@@ -1,0 +1,12 @@
+open Alcotest
+open Dia
+
+let test_create_cpp_variable () =
+  check string "variable v0" "v0" (dia_create_cpp_variable 0);
+  check string "variable v42" "v42" (dia_create_cpp_variable 42)
+
+let () =
+  run "Dia" [
+    ("dia_create_cpp_variable",
+     [test_case "creates variables" `Quick test_create_cpp_variable]);
+  ]


### PR DESCRIPTION
## Summary
- convert `test/test_dia.ml` to an Alcotest test

## Testing
- `ocamlc -c diaNode.ml && ocamlc -c predefined.ml && ocamlc -c dia.mli && ocamlc -c dia.ml && ocamlfind ocamlc -package alcotest -linkpkg diaNode.cmo predefined.cmo dia.cmo test/test_dia.ml -o test/test_dia && ./test/test_dia` *(fails: package `alcotest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686319a38900832f924df0ef6c3bc692